### PR TITLE
Avoid running success results after end_line

### DIFF
--- a/lib/bcdd/result.rb
+++ b/lib/bcdd/result.rb
@@ -12,13 +12,15 @@ require_relative 'result/expectations'
 require_relative 'result/context'
 
 class BCDD::Result
-  attr_accessor :unknown
+  attr_accessor :unknown, :end_line
 
   attr_reader :subject, :data, :type_checker
 
   protected :subject
 
   private :unknown, :unknown=, :type_checker
+
+  CONTINUED = :continued
 
   def initialize(type:, value:, subject: nil, expectations: nil)
     data = Data.new(name, type, value)
@@ -69,7 +71,7 @@ class BCDD::Result
   end
 
   def and_then(method_name = nil, context = nil)
-    return self if failure?
+    return self if end_line?
 
     method_name && block_given? and raise ::ArgumentError, 'method_name and block are mutually exclusive'
 

--- a/lib/bcdd/result/context/expectations/mixin.rb
+++ b/lib/bcdd/result/context/expectations/mixin.rb
@@ -21,7 +21,7 @@ class BCDD::Result::Context
     module Addons
       module Continuable
         private def Continue(**value)
-          Success.new(type: :continued, value: value, subject: self)
+          Success.new(type: BCDD::Result::CONTINUED, value: value, subject: self)
         end
       end
 

--- a/lib/bcdd/result/context/mixin.rb
+++ b/lib/bcdd/result/context/mixin.rb
@@ -15,7 +15,7 @@ class BCDD::Result::Context
     module Addons
       module Continuable
         private def Continue(**value)
-          Success.new(type: :continued, value: value, subject: self)
+          Success.new(type: BCDD::Result::CONTINUED, value: value, subject: self)
         end
       end
 

--- a/lib/bcdd/result/expectations/mixin.rb
+++ b/lib/bcdd/result/expectations/mixin.rb
@@ -21,7 +21,7 @@ class BCDD::Result
     module Addons
       module Continuable
         private def Continue(value)
-          Success.new(type: :continued, value: value, subject: self)
+          Success.new(type: BCDD::Result::CONTINUED, value: value, subject: self)
         end
       end
 

--- a/lib/bcdd/result/failure/methods.rb
+++ b/lib/bcdd/result/failure/methods.rb
@@ -13,6 +13,10 @@ module BCDD::Result::Failure::Methods
     yield(value)
   end
 
+  def end_line?
+    true
+  end
+
   private
 
   def name

--- a/lib/bcdd/result/mixin.rb
+++ b/lib/bcdd/result/mixin.rb
@@ -15,7 +15,7 @@ class BCDD::Result
     module Addons
       module Continuable
         private def Continue(value)
-          Success(:continued, value)
+          Success(BCDD::Result::CONTINUED, value)
         end
       end
 

--- a/lib/bcdd/result/success/methods.rb
+++ b/lib/bcdd/result/success/methods.rb
@@ -13,6 +13,20 @@ module BCDD::Result::Success::Methods
     value
   end
 
+  def and_then(...)
+    result = super
+
+    if type == BCDD::Result::CONTINUED && result.success? && result.type != BCDD::Result::CONTINUED
+      result.end_line = true
+    end
+
+    result
+  end
+
+  def end_line?
+    !!end_line
+  end
+
   private
 
   def name

--- a/lib/bcdd/result/version.rb
+++ b/lib/bcdd/result/version.rb
@@ -2,6 +2,6 @@
 
 module BCDD
   class Result
-    VERSION = '0.7.0'
+    VERSION = '0.8.0'
   end
 end

--- a/test/bcdd/result/and_then/with_subject/continue_instance_test.rb
+++ b/test/bcdd/result/and_then/with_subject/continue_instance_test.rb
@@ -56,3 +56,23 @@ class BCDD::Result::AndThenWithSubjectContinueInstanceTest < Minitest::Test
     assert_equal 'arg2 must not be zero', failure3.value
   end
 end
+
+class BCDD::Result::AndThenWithSubjectContinueFollowedBySuccessResultsInstanceTest < Minitest::Test
+  class ContinuedFollowedBySuccessResults
+    include BCDD::Result.mixin(with: :Continue)
+
+    def call
+      Continue(0)
+        .and_then { Success(:first_success, 1) }
+        .and_then { Success(:second_success, 2) }
+    end
+  end
+
+  test 'method chain interupts after the first Success' do
+    success = ContinuedFollowedBySuccessResults.new.call
+
+    assert_predicate success, :success?
+    assert_equal :first_success, success.type
+    assert_equal 1, success.value
+  end
+end

--- a/test/bcdd/result/and_then/with_subject/continue_singleton_test.rb
+++ b/test/bcdd/result/and_then/with_subject/continue_singleton_test.rb
@@ -56,3 +56,23 @@ class BCDD::Result::AndThenWithSubjectContinueSingletonTest < Minitest::Test
     assert_equal 'arg2 must not be zero', failure3.value
   end
 end
+
+class BCDD::Result::AndThenWithSubjectContinueFollowedBySuccessResultsSingletonTest < Minitest::Test
+  module ContinuedFollowedBySuccessResults
+    extend self, BCDD::Result.mixin(with: :Continue)
+
+    def call
+      Continue(0)
+        .and_then { Success(:first_success, 1) }
+        .and_then { Success(:second_success, 2) }
+    end
+  end
+
+  test 'method chain interupts after the first Success' do
+    success = ContinuedFollowedBySuccessResults.call
+
+    assert_predicate success, :success?
+    assert_equal :first_success, success.type
+    assert_equal 1, success.value
+  end
+end

--- a/test/bcdd/result/context/and_then/with_subject/continue_instance_test.rb
+++ b/test/bcdd/result/context/and_then/with_subject/continue_instance_test.rb
@@ -56,3 +56,23 @@ class BCDD::Result::Context::AndThenWithSubjectContinueInstanceTest < Minitest::
     assert_equal({ message: 'arg2 must not be zero' }, failure3.value)
   end
 end
+
+class BCDD::Result::Context::AndThenWithSubjectContinueFollowedBySuccessResultsInstanceTest < Minitest::Test
+  class ContinuedFollowedBySuccessResults
+    include BCDD::Result::Context.mixin(with: :Continue)
+
+    def call
+      Continue(value: 0)
+        .and_then { Success(:first_success, value: 1) }
+        .and_then { Success(:second_success, value: 2) }
+    end
+  end
+
+  test 'method chain interupts after the first Success' do
+    success = ContinuedFollowedBySuccessResults.new.call
+
+    assert_predicate success, :success?
+    assert_equal :first_success, success.type
+    assert_equal({ value: 1 }, success.value)
+  end
+end

--- a/test/bcdd/result/context/and_then/with_subject/continue_singleton_test.rb
+++ b/test/bcdd/result/context/and_then/with_subject/continue_singleton_test.rb
@@ -56,3 +56,23 @@ class BCDD::Result::Context::AndThenWithSubjectContinueSingletonTest < Minitest:
     assert_equal({ message: 'arg2 must not be zero' }, failure3.value)
   end
 end
+
+class BCDD::Result::Context::AndThenWithSubjectContinueFollowedBySuccessResultsSingletonTest < Minitest::Test
+  module ContinuedFollowedBySuccessResults
+    extend self, BCDD::Result::Context.mixin(with: :Continue)
+
+    def call
+      Continue(value: 0)
+        .and_then { Success(:first_success, value: 1) }
+        .and_then { Success(:second_success, value: 2) }
+    end
+  end
+
+  test 'method chain interupts after the first Success' do
+    success = ContinuedFollowedBySuccessResults.call
+
+    assert_predicate success, :success?
+    assert_equal :first_success, success.type
+    assert_equal({ value: 1 }, success.value)
+  end
+end


### PR DESCRIPTION
This PR introduces the concept of `End Line` to address issue #14. `End Line` is intended to be a playful term that evokes the Railway.

The method `and_then` checks whether the current result is an `End Line` rather than solely checking for failure.

### When to Set `End Line` for a `Result`?

 - `Failure` is always treated as an `End Line.` Therefore, it doesn`t alter the behavior for failures.

 - `Success` is considered an `End Line` if and only if a `Continue` result produces a `Success` result. Consequently, the `and_then` method will not execute blocks for success results marked as `End Line,` returning the first `Success` found after a `Continue.` For example:

```ruby

class BCDD::Result::Context::AndThenWithSubjectContinueFollowedBySuccessResultsSingletonTest < Minitest::Test
  module ContinuedFollowedBySuccessResults
    extend self, BCDD::Result.mixin(with: :Continue)

    def call
      Continue(value: 0)
        .and_then { Success(:first_success, value: 1) }
        .and_then { Success(:second_success, value: 2) }
    end
  end

  test 'Method chain interrupts after the first Success' do
    success = ContinuedFollowedBySuccessResults.call

    assert_predicate success, :success?
    assert_equal :first_success, success.type
    assert_equal({ value: 1 }, success.value)
  end
end
```

To-Do
- [ ] Discuss whether it makes sense to raise an error when attempting to execute `and_then` blocks and methods in`Success` `End Line`. Otherwise, debugging a long `and_then` chain may become challenging.
- [ ] Update the documentation in accordance with the previous discussion.