### PR TITLE
Change/Rename halted concept to terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,28 @@
 - [\[Unreleased\]](#unreleased)
+  - [Changed](#changed)
 - [\[0.10.0\] - 2023-12-31](#0100---2023-12-31)
   - [Added](#added)
 - [\[0.9.1\] - 2023-12-12](#091---2023-12-12)
-  - [Changed](#changed)
+  - [Changed](#changed-1)
   - [Fixed](#fixed)
 - [\[0.9.0\] - 2023-12-12](#090---2023-12-12)
   - [Added](#added-1)
-  - [Changed](#changed-1)
+  - [Changed](#changed-2)
 - [\[0.8.0\] - 2023-12-11](#080---2023-12-11)
   - [Added](#added-2)
-  - [Changed](#changed-2)
+  - [Changed](#changed-3)
   - [Removed](#removed)
 - [\[0.7.0\] - 2023-10-27](#070---2023-10-27)
   - [Added](#added-3)
-  - [Changed](#changed-3)
+  - [Changed](#changed-4)
 - [\[0.6.0\] - 2023-10-11](#060---2023-10-11)
   - [Added](#added-4)
-  - [Changed](#changed-4)
+  - [Changed](#changed-5)
 - [\[0.5.0\] - 2023-10-09](#050---2023-10-09)
   - [Added](#added-5)
 - [\[0.4.0\] - 2023-09-28](#040---2023-09-28)
   - [Added](#added-6)
-  - [Changed](#changed-5)
+  - [Changed](#changed-6)
   - [Removed](#removed-1)
 - [\[0.3.0\] - 2023-09-26](#030---2023-09-26)
   - [Added](#added-7)
@@ -32,6 +33,14 @@
   - [Added](#added-9)
 
 ## [Unreleased]
+
+### Changed
+
+- **(BREAKING)** Rename halted concept to terminal. Failures are terminal by default, but you can make a success terminal by enabling the `:continue` addon.
+
+- **(BREAKING)** Rename `BCDD::Result::Context::Success#and_expose` halted keyword argument to `terminal`.
+
+- **(BREAKING)** Rename `BCDD::Result#halted?` to `BCDD::Result#terminal?`.
 
 ## [0.10.0] - 2023-12-31
 
@@ -45,7 +54,7 @@
 
 ### Changed
 
-- **(BREAKING)** Make `BCDD::Result::Context::Success#and_expose()` to produce a halted success by default. You can turn this off by passing `halted: false`.
+- **(BREAKING)** Make `BCDD::Result::Context::Success#and_expose()` to produce a terminal success by default. You can turn this off by passing `halted: false`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -920,9 +920,9 @@ The `BCDD::Result.mixin` also accepts the `config:` argument. It is a hash that 
 
 **continue**
 
-This addon will create the `Continue(value)` method and change the `Success()` behavior to halt the step chain.
+This addon will create the `Continue(value)` method and change the `Success()` behavior to terminate the step chain.
 
-So, if you want to advance to the next step, you must use `Continue(value)` instead of `Success(type, value)`. Otherwise, the step chain will be halted.
+So, if you want to advance to the next step, you must use `Continue(value)` instead of `Success(type, value)`. Otherwise, the step chain will be terminated.
 
 ```ruby
 module Divide
@@ -1571,7 +1571,7 @@ Divide.new.call(10, 5)
 #<BCDD::Result::Context::Success type=:ok value={:number=>2, :number1=>10, :number2=>5}>
 ```
 
-> PS: The `#and_expose` produces a halted success by default. This means the next step will not be executed even if you call `#and_then` after `#and_expose`. To change this behavior, you can pass `halted: false` to `#and_expose`.
+> PS: The `#and_expose` produces a terminal success by default. This means the next step will not be executed even if you call `#and_then` after `#and_expose`. To change this behavior, you can pass `terminal: false` to `#and_expose`.
 
 <p align="right"><a href="#-bcddresult">⬆️ &nbsp;back to top</a></p>
 
@@ -1680,9 +1680,9 @@ The `BCDD::Result::Context.mixin` and `BCDD::Result::Context::Expectations.mixin
 
 **Continue**
 
-The `BCDD::Result::Context.mixin(config: { addon: { continue: true } })` or `BCDD::Result::Context::Expectations.mixin(config: { addon: { continue: true } })` creates the `Continue(value)` method and change the `Success()` behavior to halt the step chain.
+The `BCDD::Result::Context.mixin(config: { addon: { continue: true } })` or `BCDD::Result::Context::Expectations.mixin(config: { addon: { continue: true } })` creates the `Continue(value)` method and change the `Success()` behavior to terminate the step chain.
 
-So, if you want to advance to the next step, you must use `Continue(**value)` instead of `Success(type, **value)`. Otherwise, the step chain will be halted.
+So, if you want to advance to the next step, you must use `Continue(**value)` instead of `Success(type, **value)`. Otherwise, the step chain will be terminated.
 
 Let's use a mix of `BCDD::Result::Context` features to see in action with this add-on:
 

--- a/lib/bcdd/result.rb
+++ b/lib/bcdd/result.rb
@@ -16,7 +16,7 @@ require_relative 'result/config'
 class BCDD::Result
   attr_accessor :unknown, :transitions
 
-  attr_reader :subject, :data, :type_checker, :halted
+  attr_reader :subject, :data, :type_checker, :terminal
 
   protected :subject
 
@@ -32,12 +32,12 @@ class BCDD::Result
     config.freeze
   end
 
-  def initialize(type:, value:, subject: nil, expectations: nil, halted: nil)
+  def initialize(type:, value:, subject: nil, expectations: nil, terminal: nil)
     data = Data.new(kind, type, value)
 
     @type_checker = Contract.evaluate(data, expectations)
     @subject = subject
-    @halted = halted || kind == :failure
+    @terminal = terminal || kind == :failure
     @data = data
 
     self.unknown = true
@@ -46,8 +46,8 @@ class BCDD::Result
     Transitions.tracking.record(self)
   end
 
-  def halted?
-    halted
+  def terminal?
+    terminal
   end
 
   def type
@@ -89,7 +89,7 @@ class BCDD::Result
   end
 
   def and_then(method_name = nil, context = nil, &block)
-    return self if halted?
+    return self if terminal?
 
     method_name && block and raise ::ArgumentError, 'method_name and block are mutually exclusive'
 

--- a/lib/bcdd/result/context.rb
+++ b/lib/bcdd/result/context.rb
@@ -15,7 +15,7 @@ class BCDD::Result
       Failure.new(type: type, value: value)
     end
 
-    def initialize(type:, value:, subject: nil, expectations: nil, halted: nil)
+    def initialize(type:, value:, subject: nil, expectations: nil, terminal: nil)
       value.is_a?(::Hash) or raise ::ArgumentError, 'value must be a Hash'
 
       @acc = {}

--- a/lib/bcdd/result/context/mixin.rb
+++ b/lib/bcdd/result/context/mixin.rb
@@ -13,15 +13,15 @@ class BCDD::Result::Context
         _ResultAs(Failure, type, value)
       end
 
-      private def _ResultAs(kind_class, type, value, halted: nil)
-        kind_class.new(type: type, value: value, subject: self, halted: halted)
+      private def _ResultAs(kind_class, type, value, terminal: nil)
+        kind_class.new(type: type, value: value, subject: self, terminal: terminal)
       end
     end
 
     module Addons
       module Continuable
         def Success(type, **value)
-          _ResultAs(Success, type, value, halted: true)
+          _ResultAs(Success, type, value, terminal: true)
         end
 
         private def Continue(**value)

--- a/lib/bcdd/result/context/success.rb
+++ b/lib/bcdd/result/context/success.rb
@@ -3,13 +3,13 @@
 class BCDD::Result::Context::Success < BCDD::Result::Context
   include ::BCDD::Result::Success::Methods
 
-  def and_expose(type, keys, halted: true)
+  def and_expose(type, keys, terminal: true)
     unless keys.is_a?(::Array) && !keys.empty? && keys.all?(::Symbol)
       raise ::ArgumentError, 'keys must be an Array of Symbols'
     end
 
     exposed_value = acc.merge(value).slice(*keys)
 
-    self.class.new(type: type, value: exposed_value, subject: subject, halted: halted)
+    self.class.new(type: type, value: exposed_value, subject: subject, terminal: terminal)
   end
 end

--- a/lib/bcdd/result/expectations.rb
+++ b/lib/bcdd/result/expectations.rb
@@ -38,8 +38,8 @@ class BCDD::Result
 
     private_class_method :mixin!, :mixin_module, :result_factory_without_expectations
 
-    def initialize(subject: nil, contract: nil, halted: nil, **options)
-      @halted = halted
+    def initialize(subject: nil, contract: nil, terminal: nil, **options)
+      @terminal = terminal
 
       @subject = subject
 
@@ -60,16 +60,16 @@ class BCDD::Result
       _ResultAs(Failure, type, value)
     end
 
-    def with(subject:, halted: nil)
-      self.class.new(subject: subject, halted: halted, contract: contract)
+    def with(subject:, terminal: nil)
+      self.class.new(subject: subject, terminal: terminal, contract: contract)
     end
 
     private
 
     def _ResultAs(kind_class, type, value)
-      kind_class.new(type: type, value: value, subject: subject, expectations: contract, halted: halted)
+      kind_class.new(type: type, value: value, subject: subject, expectations: contract, terminal: terminal)
     end
 
-    attr_reader :subject, :halted, :contract
+    attr_reader :subject, :terminal, :contract
   end
 end

--- a/lib/bcdd/result/expectations/mixin.rb
+++ b/lib/bcdd/result/expectations/mixin.rb
@@ -24,14 +24,14 @@ class BCDD::Result
 
       FACTORY = <<~RUBY
         private def _Result
-          @_Result ||= Result.with(subject: self, halted: %<halted>s)
+          @_Result ||= Result.with(subject: self, terminal: %<terminal>s)
         end
       RUBY
 
       def self.to_eval(addons)
-        halted = addons.key?(:continue) ? 'true' : 'nil'
+        terminal = addons.key?(:continue) ? 'true' : 'nil'
 
-        "#{BASE}\n#{format(FACTORY, halted: halted)}"
+        "#{BASE}\n#{format(FACTORY, terminal: terminal)}"
       end
     end
 

--- a/lib/bcdd/result/mixin.rb
+++ b/lib/bcdd/result/mixin.rb
@@ -20,15 +20,15 @@ class BCDD::Result
         _ResultAs(Failure, type, value)
       end
 
-      private def _ResultAs(kind_class, type, value, halted: nil)
-        kind_class.new(type: type, value: value, subject: self, halted: halted)
+      private def _ResultAs(kind_class, type, value, terminal: nil)
+        kind_class.new(type: type, value: value, subject: self, terminal: terminal)
       end
     end
 
     module Addons
       module Continuable
         def Success(type, value = nil)
-          _ResultAs(Success, type, value, halted: true)
+          _ResultAs(Success, type, value, terminal: true)
         end
 
         private def Continue(value)

--- a/sig/bcdd/result.rbs
+++ b/sig/bcdd/result.rbs
@@ -5,7 +5,7 @@ class BCDD::Result
 
   attr_reader data: BCDD::Result::Data
   attr_reader subject: untyped
-  attr_reader halted: bool
+  attr_reader terminal: bool
   attr_reader transitions: Hash[Symbol, untyped]
 
   def self.config: -> BCDD::Result::Config
@@ -16,13 +16,13 @@ class BCDD::Result
     value: untyped,
     ?subject: untyped,
     ?expectations: BCDD::Result::Contract::Evaluator,
-    ?halted: bool
+    ?terminal: bool
   ) -> void
 
   def type: -> Symbol
   def value: -> untyped
 
-  def halted?: -> bool
+  def terminal?: -> bool
   def success?: (?Symbol type) -> bool
   def failure?: (?Symbol type) -> bool
 

--- a/sig/bcdd/result/context.rbs
+++ b/sig/bcdd/result/context.rbs
@@ -10,7 +10,7 @@ class BCDD::Result::Context < BCDD::Result
     value: untyped,
     ?subject: untyped,
     ?expectations: BCDD::Result::Contract::Evaluator,
-    ?halted: bool
+    ?terminal: bool
   ) -> void
 
   def and_then: (?Symbol, **untyped) ?{ (Hash[Symbol, untyped]) -> untyped } -> BCDD::Result::Context
@@ -27,7 +27,7 @@ class BCDD::Result::Context
   class Success < BCDD::Result::Context
     include BCDD::Result::Success::Methods
 
-    def and_expose: (Symbol, Array[Symbol], halted: bool) -> BCDD::Result::Context::Success
+    def and_expose: (Symbol, Array[Symbol], terminal: bool) -> BCDD::Result::Context::Success
   end
 
   def self.Success: (Symbol, **untyped) -> BCDD::Result::Context::Success
@@ -54,7 +54,7 @@ class BCDD::Result::Context
 
       private
 
-      def _ResultAs: (singleton(BCDD::Result::Context), Symbol, untyped, ?halted: bool) -> untyped
+      def _ResultAs: (singleton(BCDD::Result::Context), Symbol, untyped, ?terminal: bool) -> untyped
     end
 
     module Addons

--- a/sig/bcdd/result/expectations.rbs
+++ b/sig/bcdd/result/expectations.rbs
@@ -18,14 +18,14 @@ class BCDD::Result::Expectations
   def self.new: (
     ?subject: untyped,
     ?contract: BCDD::Result::Contract::Evaluator,
-    ?halted: bool,
+    ?terminal: bool,
     **untyped
   ) -> (BCDD::Result::Expectations | untyped)
 
   def initialize: (
     ?subject: untyped,
     ?contract: BCDD::Result::Contract::Evaluator,
-    ?halted: bool,
+    ?terminal: bool,
     **untyped
   ) -> void
 
@@ -40,7 +40,7 @@ class BCDD::Result::Expectations
 
   attr_reader subject: untyped
   attr_reader contract: BCDD::Result::Contract::Evaluator
-  attr_reader halted: bool
+  attr_reader terminal: bool
 end
 
 module BCDD::Result::Expectations::Mixin

--- a/sig/bcdd/result/mixin.rbs
+++ b/sig/bcdd/result/mixin.rbs
@@ -11,7 +11,7 @@ class BCDD::Result
 
       private
 
-      def _ResultAs: (singleton(BCDD::Result), Symbol, untyped, ?halted: bool) -> untyped
+      def _ResultAs: (singleton(BCDD::Result), Symbol, untyped, ?terminal: bool) -> untyped
     end
 
     module Addons

--- a/test/bcdd/result/and_then/with_subject/continue_instance_test.rb
+++ b/test/bcdd/result/and_then/with_subject/continue_instance_test.rb
@@ -56,7 +56,7 @@ class BCDD::Result::AndThenWithSubjectContinueInstanceTest < Minitest::Test
     assert_equal 'arg2 must not be zero', failure3.value
   end
 
-  class FirstSuccessHaltsTheStepChainAndThenBlock
+  class FirstSuccessToTerminateTheStepChainAndThenBlock
     include BCDD::Result.mixin(config: { addon: { continue: true } })
 
     def call
@@ -66,7 +66,7 @@ class BCDD::Result::AndThenWithSubjectContinueInstanceTest < Minitest::Test
     end
   end
 
-  class SecondSuccessHaltsTheStepChainAndThenBlock
+  class SecondSuccessToTerminateTheStepChainAndThenBlock
     include BCDD::Result.mixin(config: { addon: { continue: true } })
 
     def call
@@ -76,7 +76,7 @@ class BCDD::Result::AndThenWithSubjectContinueInstanceTest < Minitest::Test
     end
   end
 
-  class ThirdSuccessHaltsTheStepChainAndThenBlock
+  class ThirdSuccessToTerminateTheStepChainAndThenBlock
     include BCDD::Result.mixin(config: { addon: { continue: true } })
 
     def call
@@ -86,17 +86,17 @@ class BCDD::Result::AndThenWithSubjectContinueInstanceTest < Minitest::Test
     end
   end
 
-  test 'the step chain halting (and_then block)' do
-    result1 = FirstSuccessHaltsTheStepChainAndThenBlock.new.call
-    result2 = SecondSuccessHaltsTheStepChainAndThenBlock.new.call
-    result3 = ThirdSuccessHaltsTheStepChainAndThenBlock.new.call
+  test 'the step chain termination (and_then block)' do
+    result1 = FirstSuccessToTerminateTheStepChainAndThenBlock.new.call
+    result2 = SecondSuccessToTerminateTheStepChainAndThenBlock.new.call
+    result3 = ThirdSuccessToTerminateTheStepChainAndThenBlock.new.call
 
-    assert(result1.success?(:first) && result1.halted?)
-    assert(result2.success?(:second) && result2.halted?)
-    assert(result3.success?(:third) && result3.halted?)
+    assert(result1.success?(:first) && result1.terminal?)
+    assert(result2.success?(:second) && result2.terminal?)
+    assert(result3.success?(:third) && result3.terminal?)
   end
 
-  class FirstSuccessHaltsTheStepChainAndThenMethod
+  class FirstSuccessToTerminateTheStepChainAndThenMethod
     include BCDD::Result.mixin(config: { addon: { continue: true } })
 
     def call
@@ -112,7 +112,7 @@ class BCDD::Result::AndThenWithSubjectContinueInstanceTest < Minitest::Test
     def third_success;  Continue(:third); end
   end
 
-  class SecondSuccessHaltsTheStepChainAndThenMethod
+  class SecondSuccessToTerminateTheStepChainAndThenMethod
     include BCDD::Result.mixin(config: { addon: { continue: true } })
 
     def call
@@ -128,7 +128,7 @@ class BCDD::Result::AndThenWithSubjectContinueInstanceTest < Minitest::Test
     def third_success;  Continue(:third); end
   end
 
-  class ThirdSuccessHaltsTheStepChainAndThenMethod
+  class ThirdSuccessToTerminateTheStepChainAndThenMethod
     include BCDD::Result.mixin(config: { addon: { continue: true } })
 
     def call
@@ -144,13 +144,13 @@ class BCDD::Result::AndThenWithSubjectContinueInstanceTest < Minitest::Test
     def third_success;  Success(:third); end
   end
 
-  test 'the step chain halting (and_then calling a method)' do
-    result1 = FirstSuccessHaltsTheStepChainAndThenMethod.new.call
-    result2 = SecondSuccessHaltsTheStepChainAndThenMethod.new.call
-    result3 = ThirdSuccessHaltsTheStepChainAndThenMethod.new.call
+  test 'the step chain termination (and_then calling a method)' do
+    result1 = FirstSuccessToTerminateTheStepChainAndThenMethod.new.call
+    result2 = SecondSuccessToTerminateTheStepChainAndThenMethod.new.call
+    result3 = ThirdSuccessToTerminateTheStepChainAndThenMethod.new.call
 
-    assert(result1.success?(:first) && result1.halted?)
-    assert(result2.success?(:second) && result2.halted?)
-    assert(result3.success?(:third) && result3.halted?)
+    assert(result1.success?(:first) && result1.terminal?)
+    assert(result2.success?(:second) && result2.terminal?)
+    assert(result3.success?(:third) && result3.terminal?)
   end
 end

--- a/test/bcdd/result/and_then/with_subject/continue_singleton_test.rb
+++ b/test/bcdd/result/and_then/with_subject/continue_singleton_test.rb
@@ -56,7 +56,7 @@ class BCDD::Result::AndThenWithSubjectContinueSingletonTest < Minitest::Test
     assert_equal 'arg2 must not be zero', failure3.value
   end
 
-  module FirstSuccessHaltsTheStepChainAndThenBlock
+  module FirstSuccessToTerminateTheStepChainAndThenBlock
     extend self, BCDD::Result.mixin(config: { addon: { continue: true } })
 
     def call
@@ -66,7 +66,7 @@ class BCDD::Result::AndThenWithSubjectContinueSingletonTest < Minitest::Test
     end
   end
 
-  module SecondSuccessHaltsTheStepChainAndThenBlock
+  module SecondSuccessToTerminateTheStepChainAndThenBlock
     extend self, BCDD::Result.mixin(config: { addon: { continue: true } })
 
     def call
@@ -76,7 +76,7 @@ class BCDD::Result::AndThenWithSubjectContinueSingletonTest < Minitest::Test
     end
   end
 
-  module ThirdSuccessHaltsTheStepChainAndThenBlock
+  module ThirdSuccessToTerminateTheStepChainAndThenBlock
     extend self, BCDD::Result.mixin(config: { addon: { continue: true } })
 
     def call
@@ -86,17 +86,17 @@ class BCDD::Result::AndThenWithSubjectContinueSingletonTest < Minitest::Test
     end
   end
 
-  test 'the step chain halting (and_then block)' do
-    result1 = FirstSuccessHaltsTheStepChainAndThenBlock.call
-    result2 = SecondSuccessHaltsTheStepChainAndThenBlock.call
-    result3 = ThirdSuccessHaltsTheStepChainAndThenBlock.call
+  test 'the step chain termination (and_then block)' do
+    result1 = FirstSuccessToTerminateTheStepChainAndThenBlock.call
+    result2 = SecondSuccessToTerminateTheStepChainAndThenBlock.call
+    result3 = ThirdSuccessToTerminateTheStepChainAndThenBlock.call
 
-    assert(result1.success?(:first) && result1.halted?)
-    assert(result2.success?(:second) && result2.halted?)
-    assert(result3.success?(:third) && result3.halted?)
+    assert(result1.success?(:first) && result1.terminal?)
+    assert(result2.success?(:second) && result2.terminal?)
+    assert(result3.success?(:third) && result3.terminal?)
   end
 
-  module FirstSuccessHaltsTheStepChainAndThenMethod
+  module FirstSuccessToTerminateTheStepChainAndThenMethod
     extend self, BCDD::Result.mixin(config: { addon: { continue: true } })
 
     def call
@@ -112,7 +112,7 @@ class BCDD::Result::AndThenWithSubjectContinueSingletonTest < Minitest::Test
     def third_success;  Continue(:third); end
   end
 
-  module SecondSuccessHaltsTheStepChainAndThenMethod
+  module SecondSuccessToTerminateTheStepChainAndThenMethod
     extend self, BCDD::Result.mixin(config: { addon: { continue: true } })
 
     def call
@@ -128,7 +128,7 @@ class BCDD::Result::AndThenWithSubjectContinueSingletonTest < Minitest::Test
     def third_success;  Continue(:third); end
   end
 
-  module ThirdSuccessHaltsTheStepChainAndThenMethod
+  module ThirdSuccessToTerminateTheStepChainAndThenMethod
     extend self, BCDD::Result.mixin(config: { addon: { continue: true } })
 
     def call
@@ -144,13 +144,13 @@ class BCDD::Result::AndThenWithSubjectContinueSingletonTest < Minitest::Test
     def third_success;  Success(:third); end
   end
 
-  test 'the step chain halting (and_then calling a method)' do
-    result1 = FirstSuccessHaltsTheStepChainAndThenMethod.call
-    result2 = SecondSuccessHaltsTheStepChainAndThenMethod.call
-    result3 = ThirdSuccessHaltsTheStepChainAndThenMethod.call
+  test 'the step chain termination (and_then calling a method)' do
+    result1 = FirstSuccessToTerminateTheStepChainAndThenMethod.call
+    result2 = SecondSuccessToTerminateTheStepChainAndThenMethod.call
+    result3 = ThirdSuccessToTerminateTheStepChainAndThenMethod.call
 
-    assert(result1.success?(:first) && result1.halted?)
-    assert(result2.success?(:second) && result2.halted?)
-    assert(result3.success?(:third) && result3.halted?)
+    assert(result1.success?(:first) && result1.terminal?)
+    assert(result2.success?(:second) && result2.terminal?)
+    assert(result3.success?(:third) && result3.terminal?)
   end
 end

--- a/test/bcdd/result/context/and_expose/termination_test.rb
+++ b/test/bcdd/result/context/and_expose/termination_test.rb
@@ -3,25 +3,25 @@
 require 'test_helper'
 
 class BCDD::Result
-  class ContextHaltingTest < Minitest::Test
-    module HaltingEnabledAndThenBlock
+  class ContextTerminationTest < Minitest::Test
+    module TerminationEnabledAndThenBlock
       extend self, Context.mixin
 
       def call
         Success(:a, a: 1)
           .and_then { Success(:b, b: 2) }
-          .and_expose(:a_and_b, %i[a b])  # the default is halted
+          .and_expose(:a_and_b, %i[a b])  # the default is terminal
           .and_then { Success(:c, c: 3) }
       end
     end
 
-    module HaltingEnabledAndThenMethod
+    module TerminationEnabledAndThenMethod
       extend self, Context.mixin
 
       def call
         call_a
           .and_then(:call_b)
-          .and_expose(:a_and_b, %i[a b])  # the default is halted
+          .and_expose(:a_and_b, %i[a b])  # the default is terminal
           .and_then(:call_c)
       end
 
@@ -32,24 +32,24 @@ class BCDD::Result
       def call_c; Success(:c, c: 3); end
     end
 
-    module HaltingDisabledAndThenBlock
+    module TerminationDisabledAndThenBlock
       extend self, Context.mixin
 
       def call
         Success(:a, a: 1)
           .and_then { Success(:b, b: 2) }
-          .and_expose(:a_and_b, %i[a b], halted: false)
+          .and_expose(:a_and_b, %i[a b], terminal: false)
           .and_then { Success(:c, c: 3) }
       end
     end
 
-    module HaltingDisabledAndThenMethod
+    module TerminationDisabledAndThenMethod
       extend self, Context.mixin
 
       def call
         call_a
           .and_then(:call_b)
-          .and_expose(:a_and_b, %i[a b], halted: false)
+          .and_expose(:a_and_b, %i[a b], terminal: false)
           .and_then(:call_c)
       end
 
@@ -60,9 +60,9 @@ class BCDD::Result
       def call_c; Success(:c, c: 3); end
     end
 
-    test 'by default, #and_expose halts the execution' do
-      result1 = HaltingEnabledAndThenBlock.call
-      result2 = HaltingEnabledAndThenMethod.call
+    test 'by default, #and_expose terminates the execution' do
+      result1 = TerminationEnabledAndThenBlock.call
+      result2 = TerminationEnabledAndThenMethod.call
 
       assert result1.success?(:a_and_b)
       assert_equal({ a: 1, b: 2 }, result1.value)
@@ -71,9 +71,9 @@ class BCDD::Result
       assert_equal({ a: 1, b: 2 }, result2.value)
     end
 
-    test 'when halted is false, #and_expose does not halt the execution' do
-      result1 = HaltingDisabledAndThenBlock.call
-      result2 = HaltingDisabledAndThenMethod.call
+    test 'when terminal is false, #and_expose does not terminates the execution' do
+      result1 = TerminationDisabledAndThenBlock.call
+      result2 = TerminationDisabledAndThenMethod.call
 
       assert result1.success?(:c)
       assert_equal({ c: 3 }, result1.value)

--- a/test/bcdd/result/context/and_then/with_subject/continue_instance_test.rb
+++ b/test/bcdd/result/context/and_then/with_subject/continue_instance_test.rb
@@ -56,7 +56,7 @@ class BCDD::Result::Context::AndThenWithSubjectContinueInstanceTest < Minitest::
     assert_equal({ message: 'arg2 must not be zero' }, failure3.value)
   end
 
-  class FirstSuccessHaltsTheStepChainAndThenBlock
+  class FirstSuccessToTerminateTheStepChainAndThenBlock
     include BCDD::Result::Context.mixin(config: { addon: { continue: true } })
 
     def call
@@ -66,7 +66,7 @@ class BCDD::Result::Context::AndThenWithSubjectContinueInstanceTest < Minitest::
     end
   end
 
-  class SecondSuccessHaltsTheStepChainAndThenBlock
+  class SecondSuccessToTerminateTheStepChainAndThenBlock
     include BCDD::Result::Context.mixin(config: { addon: { continue: true } })
 
     def call
@@ -76,7 +76,7 @@ class BCDD::Result::Context::AndThenWithSubjectContinueInstanceTest < Minitest::
     end
   end
 
-  class ThirdSuccessHaltsTheStepChainAndThenBlock
+  class ThirdSuccessToTerminateTheStepChainAndThenBlock
     include BCDD::Result::Context.mixin(config: { addon: { continue: true } })
 
     def call
@@ -86,17 +86,17 @@ class BCDD::Result::Context::AndThenWithSubjectContinueInstanceTest < Minitest::
     end
   end
 
-  test 'the step chain halting (and_then block)' do
-    result1 = FirstSuccessHaltsTheStepChainAndThenBlock.new.call
-    result2 = SecondSuccessHaltsTheStepChainAndThenBlock.new.call
-    result3 = ThirdSuccessHaltsTheStepChainAndThenBlock.new.call
+  test 'the step chain termination (and_then block)' do
+    result1 = FirstSuccessToTerminateTheStepChainAndThenBlock.new.call
+    result2 = SecondSuccessToTerminateTheStepChainAndThenBlock.new.call
+    result3 = ThirdSuccessToTerminateTheStepChainAndThenBlock.new.call
 
-    assert(result1.success?(:first) && result1.halted?)
-    assert(result2.success?(:second) && result2.halted?)
-    assert(result3.success?(:third) && result3.halted?)
+    assert(result1.success?(:first) && result1.terminal?)
+    assert(result2.success?(:second) && result2.terminal?)
+    assert(result3.success?(:third) && result3.terminal?)
   end
 
-  class FirstSuccessHaltsTheStepChainAndThenMethod
+  class FirstSuccessToTerminateTheStepChainAndThenMethod
     include BCDD::Result::Context.mixin(config: { addon: { continue: true } })
 
     def call
@@ -112,7 +112,7 @@ class BCDD::Result::Context::AndThenWithSubjectContinueInstanceTest < Minitest::
     def third_success;  Continue(third: true); end
   end
 
-  class SecondSuccessHaltsTheStepChainAndThenMethod
+  class SecondSuccessToTerminateTheStepChainAndThenMethod
     include BCDD::Result::Context.mixin(config: { addon: { continue: true } })
 
     def call
@@ -128,7 +128,7 @@ class BCDD::Result::Context::AndThenWithSubjectContinueInstanceTest < Minitest::
     def third_success;  Continue(third: true); end
   end
 
-  class ThirdSuccessHaltsTheStepChainAndThenMethod
+  class ThirdSuccessToTerminateTheStepChainAndThenMethod
     include BCDD::Result::Context.mixin(config: { addon: { continue: true } })
 
     def call
@@ -144,13 +144,13 @@ class BCDD::Result::Context::AndThenWithSubjectContinueInstanceTest < Minitest::
     def third_success;  Success(:third); end
   end
 
-  test 'the step chain halting (and_then calling a method)' do
-    result1 = FirstSuccessHaltsTheStepChainAndThenMethod.new.call
-    result2 = SecondSuccessHaltsTheStepChainAndThenMethod.new.call
-    result3 = ThirdSuccessHaltsTheStepChainAndThenMethod.new.call
+  test 'the step chain termination (and_then calling a method)' do
+    result1 = FirstSuccessToTerminateTheStepChainAndThenMethod.new.call
+    result2 = SecondSuccessToTerminateTheStepChainAndThenMethod.new.call
+    result3 = ThirdSuccessToTerminateTheStepChainAndThenMethod.new.call
 
-    assert(result1.success?(:first) && result1.halted?)
-    assert(result2.success?(:second) && result2.halted?)
-    assert(result3.success?(:third) && result3.halted?)
+    assert(result1.success?(:first) && result1.terminal?)
+    assert(result2.success?(:second) && result2.terminal?)
+    assert(result3.success?(:third) && result3.terminal?)
   end
 end

--- a/test/bcdd/result/context/and_then/with_subject/continue_singleton_test.rb
+++ b/test/bcdd/result/context/and_then/with_subject/continue_singleton_test.rb
@@ -56,7 +56,7 @@ class BCDD::Result::Context::AndThenWithSubjectContinueSingletonTest < Minitest:
     assert_equal({ message: 'arg2 must not be zero' }, failure3.value)
   end
 
-  module FirstSuccessHaltsTheStepChainAndThenBlock
+  module FirstSuccessToTerminateTheStepChainAndThenBlock
     extend self, BCDD::Result::Context.mixin(config: { addon: { continue: true } })
 
     def call
@@ -66,7 +66,7 @@ class BCDD::Result::Context::AndThenWithSubjectContinueSingletonTest < Minitest:
     end
   end
 
-  module SecondSuccessHaltsTheStepChainAndThenBlock
+  module SecondSuccessToTerminateTheStepChainAndThenBlock
     extend self, BCDD::Result::Context.mixin(config: { addon: { continue: true } })
 
     def call
@@ -76,7 +76,7 @@ class BCDD::Result::Context::AndThenWithSubjectContinueSingletonTest < Minitest:
     end
   end
 
-  module ThirdSuccessHaltsTheStepChainAndThenBlock
+  module ThirdSuccessToTerminateTheStepChainAndThenBlock
     extend self, BCDD::Result::Context.mixin(config: { addon: { continue: true } })
 
     def call
@@ -86,17 +86,17 @@ class BCDD::Result::Context::AndThenWithSubjectContinueSingletonTest < Minitest:
     end
   end
 
-  test 'the step chain halting (and_then block)' do
-    result1 = FirstSuccessHaltsTheStepChainAndThenBlock.call
-    result2 = SecondSuccessHaltsTheStepChainAndThenBlock.call
-    result3 = ThirdSuccessHaltsTheStepChainAndThenBlock.call
+  test 'the step chain termination (and_then block)' do
+    result1 = FirstSuccessToTerminateTheStepChainAndThenBlock.call
+    result2 = SecondSuccessToTerminateTheStepChainAndThenBlock.call
+    result3 = ThirdSuccessToTerminateTheStepChainAndThenBlock.call
 
-    assert(result1.success?(:first) && result1.halted?)
-    assert(result2.success?(:second) && result2.halted?)
-    assert(result3.success?(:third) && result3.halted?)
+    assert(result1.success?(:first) && result1.terminal?)
+    assert(result2.success?(:second) && result2.terminal?)
+    assert(result3.success?(:third) && result3.terminal?)
   end
 
-  module FirstSuccessHaltsTheStepChainAndThenMethod
+  module FirstSuccessToTerminateTheStepChainAndThenMethod
     extend self, BCDD::Result::Context.mixin(config: { addon: { continue: true } })
 
     def call
@@ -112,7 +112,7 @@ class BCDD::Result::Context::AndThenWithSubjectContinueSingletonTest < Minitest:
     def third_success;  Continue(third: true); end
   end
 
-  module SecondSuccessHaltsTheStepChainAndThenMethod
+  module SecondSuccessToTerminateTheStepChainAndThenMethod
     extend self, BCDD::Result::Context.mixin(config: { addon: { continue: true } })
 
     def call
@@ -128,7 +128,7 @@ class BCDD::Result::Context::AndThenWithSubjectContinueSingletonTest < Minitest:
     def third_success;  Continue(third: true); end
   end
 
-  module ThirdSuccessHaltsTheStepChainAndThenMethod
+  module ThirdSuccessToTerminateTheStepChainAndThenMethod
     extend self, BCDD::Result::Context.mixin(config: { addon: { continue: true } })
 
     def call
@@ -144,13 +144,13 @@ class BCDD::Result::Context::AndThenWithSubjectContinueSingletonTest < Minitest:
     def third_success;  Success(:third); end
   end
 
-  test 'the step chain halting (and_then calling a method)' do
-    result1 = FirstSuccessHaltsTheStepChainAndThenMethod.call
-    result2 = SecondSuccessHaltsTheStepChainAndThenMethod.call
-    result3 = ThirdSuccessHaltsTheStepChainAndThenMethod.call
+  test 'the step chain termination (and_then calling a method)' do
+    result1 = FirstSuccessToTerminateTheStepChainAndThenMethod.call
+    result2 = SecondSuccessToTerminateTheStepChainAndThenMethod.call
+    result3 = ThirdSuccessToTerminateTheStepChainAndThenMethod.call
 
-    assert(result1.success?(:first) && result1.halted?)
-    assert(result2.success?(:second) && result2.halted?)
-    assert(result3.success?(:third) && result3.halted?)
+    assert(result1.success?(:first) && result1.terminal?)
+    assert(result2.success?(:second) && result2.terminal?)
+    assert(result3.success?(:third) && result3.terminal?)
   end
 end

--- a/test/bcdd/result/context/expectations/with_subject/continue_test.rb
+++ b/test/bcdd/result/context/expectations/with_subject/continue_test.rb
@@ -143,7 +143,7 @@ class BCDD::Result::Context::ExpectationsWithSubjectSuccessTypeTest < Minitest::
     assert_raises(BCDD::Result::Contract::Error::UnexpectedType) { failure3.failure?(:err) }
   end
 
-  class InstanceFirstSuccessHaltsTheStepChainAndThenBlock
+  class InstanceFirstSuccessToTerminateTheStepChainAndThenBlock
     include BCDD::Result::Context::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :first
@@ -156,7 +156,7 @@ class BCDD::Result::Context::ExpectationsWithSubjectSuccessTypeTest < Minitest::
     end
   end
 
-  class InstanceSecondSuccessHaltsTheStepChainAndThenBlock
+  class InstanceSecondSuccessToTerminateTheStepChainAndThenBlock
     include BCDD::Result::Context::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :second
@@ -169,7 +169,7 @@ class BCDD::Result::Context::ExpectationsWithSubjectSuccessTypeTest < Minitest::
     end
   end
 
-  class InstanceThirdSuccessHaltsTheStepChainAndThenBlock
+  class InstanceThirdSuccessToTerminateTheStepChainAndThenBlock
     include BCDD::Result::Context::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :third
@@ -182,7 +182,7 @@ class BCDD::Result::Context::ExpectationsWithSubjectSuccessTypeTest < Minitest::
     end
   end
 
-  module SingletonFirstSuccessHaltsTheStepChainAndThenBlock
+  module SingletonFirstSuccessToTerminateTheStepChainAndThenBlock
     extend self, BCDD::Result::Context::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :first
@@ -195,7 +195,7 @@ class BCDD::Result::Context::ExpectationsWithSubjectSuccessTypeTest < Minitest::
     end
   end
 
-  module SingletonSecondSuccessHaltsTheStepChainAndThenBlock
+  module SingletonSecondSuccessToTerminateTheStepChainAndThenBlock
     extend self, BCDD::Result::Context::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :second
@@ -208,7 +208,7 @@ class BCDD::Result::Context::ExpectationsWithSubjectSuccessTypeTest < Minitest::
     end
   end
 
-  module SingletonThirdSuccessHaltsTheStepChainAndThenBlock
+  module SingletonThirdSuccessToTerminateTheStepChainAndThenBlock
     extend self, BCDD::Result::Context::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :third
@@ -221,25 +221,25 @@ class BCDD::Result::Context::ExpectationsWithSubjectSuccessTypeTest < Minitest::
     end
   end
 
-  test 'the step chain halting (and_then block)' do
-    instance_result1 = InstanceFirstSuccessHaltsTheStepChainAndThenBlock.new.call
-    instance_result2 = InstanceSecondSuccessHaltsTheStepChainAndThenBlock.new.call
-    instance_result3 = InstanceThirdSuccessHaltsTheStepChainAndThenBlock.new.call
+  test 'the step chain termination (and_then block)' do
+    instance_result1 = InstanceFirstSuccessToTerminateTheStepChainAndThenBlock.new.call
+    instance_result2 = InstanceSecondSuccessToTerminateTheStepChainAndThenBlock.new.call
+    instance_result3 = InstanceThirdSuccessToTerminateTheStepChainAndThenBlock.new.call
 
-    singleton_result1 = SingletonFirstSuccessHaltsTheStepChainAndThenBlock.call
-    singleton_result2 = SingletonSecondSuccessHaltsTheStepChainAndThenBlock.call
-    singleton_result3 = SingletonThirdSuccessHaltsTheStepChainAndThenBlock.call
+    singleton_result1 = SingletonFirstSuccessToTerminateTheStepChainAndThenBlock.call
+    singleton_result2 = SingletonSecondSuccessToTerminateTheStepChainAndThenBlock.call
+    singleton_result3 = SingletonThirdSuccessToTerminateTheStepChainAndThenBlock.call
 
-    assert(instance_result1.success?(:first) && instance_result1.halted?)
-    assert(instance_result2.success?(:second) && instance_result2.halted?)
-    assert(instance_result3.success?(:third) && instance_result3.halted?)
+    assert(instance_result1.success?(:first) && instance_result1.terminal?)
+    assert(instance_result2.success?(:second) && instance_result2.terminal?)
+    assert(instance_result3.success?(:third) && instance_result3.terminal?)
 
-    assert(singleton_result1.success?(:first) && singleton_result1.halted?)
-    assert(singleton_result2.success?(:second) && singleton_result2.halted?)
-    assert(singleton_result3.success?(:third) && singleton_result3.halted?)
+    assert(singleton_result1.success?(:first) && singleton_result1.terminal?)
+    assert(singleton_result2.success?(:second) && singleton_result2.terminal?)
+    assert(singleton_result3.success?(:third) && singleton_result3.terminal?)
   end
 
-  class InstanceFirstSuccessHaltsTheStepChainAndThenMethod
+  class InstanceFirstSuccessToTerminateTheStepChainAndThenMethod
     include BCDD::Result::Context::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :first
@@ -258,7 +258,7 @@ class BCDD::Result::Context::ExpectationsWithSubjectSuccessTypeTest < Minitest::
     def third_success;  Continue(third: true); end
   end
 
-  class InstanceSecondSuccessHaltsTheStepChainAndThenMethod
+  class InstanceSecondSuccessToTerminateTheStepChainAndThenMethod
     include BCDD::Result::Context::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :second
@@ -277,7 +277,7 @@ class BCDD::Result::Context::ExpectationsWithSubjectSuccessTypeTest < Minitest::
     def third_success;  Continue(third: true); end
   end
 
-  class InstanceThirdSuccessHaltsTheStepChainAndThenMethod
+  class InstanceThirdSuccessToTerminateTheStepChainAndThenMethod
     include BCDD::Result::Context::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :third
@@ -296,7 +296,7 @@ class BCDD::Result::Context::ExpectationsWithSubjectSuccessTypeTest < Minitest::
     def third_success;  Success(:third); end
   end
 
-  module SingletonFirstSuccessHaltsTheStepChainAndThenMethod
+  module SingletonFirstSuccessToTerminateTheStepChainAndThenMethod
     extend self, BCDD::Result::Context::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :first
@@ -315,7 +315,7 @@ class BCDD::Result::Context::ExpectationsWithSubjectSuccessTypeTest < Minitest::
     def third_success;  Continue(third: true); end
   end
 
-  module SingletonSecondSuccessHaltsTheStepChainAndThenMethod
+  module SingletonSecondSuccessToTerminateTheStepChainAndThenMethod
     extend self, BCDD::Result::Context::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :second
@@ -334,7 +334,7 @@ class BCDD::Result::Context::ExpectationsWithSubjectSuccessTypeTest < Minitest::
     def third_success;  Continue(third: true); end
   end
 
-  module SingletonThirdSuccessHaltsTheStepChainAndThenMethod
+  module SingletonThirdSuccessToTerminateTheStepChainAndThenMethod
     extend self, BCDD::Result::Context::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :third
@@ -353,13 +353,13 @@ class BCDD::Result::Context::ExpectationsWithSubjectSuccessTypeTest < Minitest::
     def third_success;  Success(:third); end
   end
 
-  test 'the step chain halting (and_then calling a method)' do
-    instance_result1 = InstanceFirstSuccessHaltsTheStepChainAndThenMethod.new.call
-    instance_result2 = InstanceSecondSuccessHaltsTheStepChainAndThenMethod.new.call
-    instance_result3 = InstanceThirdSuccessHaltsTheStepChainAndThenMethod.new.call
+  test 'the step chain termination (and_then calling a method)' do
+    instance_result1 = InstanceFirstSuccessToTerminateTheStepChainAndThenMethod.new.call
+    instance_result2 = InstanceSecondSuccessToTerminateTheStepChainAndThenMethod.new.call
+    instance_result3 = InstanceThirdSuccessToTerminateTheStepChainAndThenMethod.new.call
 
-    assert(instance_result1.success?(:first) && instance_result1.halted?)
-    assert(instance_result2.success?(:second) && instance_result2.halted?)
-    assert(instance_result3.success?(:third) && instance_result3.halted?)
+    assert(instance_result1.success?(:first) && instance_result1.terminal?)
+    assert(instance_result2.success?(:second) && instance_result2.terminal?)
+    assert(instance_result3.success?(:third) && instance_result3.terminal?)
   end
 end

--- a/test/bcdd/result/expectations/with_subject/continue_test.rb
+++ b/test/bcdd/result/expectations/with_subject/continue_test.rb
@@ -130,7 +130,7 @@ class BCDD::Result::ExpectationsWithSubjectSuccessTypeTest < Minitest::Test
     assert_raises(BCDD::Result::Contract::Error::UnexpectedType) { failure3.failure?(:err) }
   end
 
-  class InstanceFirstSuccessHaltsTheStepChainAndThenBlock
+  class InstanceFirstSuccessToTerminateTheStepChainAndThenBlock
     include BCDD::Result::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :first
@@ -143,7 +143,7 @@ class BCDD::Result::ExpectationsWithSubjectSuccessTypeTest < Minitest::Test
     end
   end
 
-  class InstanceSecondSuccessHaltsTheStepChainAndThenBlock
+  class InstanceSecondSuccessToTerminateTheStepChainAndThenBlock
     include BCDD::Result::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :second
@@ -156,7 +156,7 @@ class BCDD::Result::ExpectationsWithSubjectSuccessTypeTest < Minitest::Test
     end
   end
 
-  class InstanceThirdSuccessHaltsTheStepChainAndThenBlock
+  class InstanceThirdSuccessToTerminateTheStepChainAndThenBlock
     include BCDD::Result::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :third
@@ -169,7 +169,7 @@ class BCDD::Result::ExpectationsWithSubjectSuccessTypeTest < Minitest::Test
     end
   end
 
-  module SingletonFirstSuccessHaltsTheStepChainAndThenBlock
+  module SingletonFirstSuccessToTerminateTheStepChainAndThenBlock
     extend self, BCDD::Result::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :first
@@ -182,7 +182,7 @@ class BCDD::Result::ExpectationsWithSubjectSuccessTypeTest < Minitest::Test
     end
   end
 
-  module SingletonSecondSuccessHaltsTheStepChainAndThenBlock
+  module SingletonSecondSuccessToTerminateTheStepChainAndThenBlock
     extend self, BCDD::Result::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :second
@@ -195,7 +195,7 @@ class BCDD::Result::ExpectationsWithSubjectSuccessTypeTest < Minitest::Test
     end
   end
 
-  module SingletonThirdSuccessHaltsTheStepChainAndThenBlock
+  module SingletonThirdSuccessToTerminateTheStepChainAndThenBlock
     extend self, BCDD::Result::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :third
@@ -208,25 +208,25 @@ class BCDD::Result::ExpectationsWithSubjectSuccessTypeTest < Minitest::Test
     end
   end
 
-  test 'the step chain halting (and_then block)' do
-    instance_result1 = InstanceFirstSuccessHaltsTheStepChainAndThenBlock.new.call
-    instance_result2 = InstanceSecondSuccessHaltsTheStepChainAndThenBlock.new.call
-    instance_result3 = InstanceThirdSuccessHaltsTheStepChainAndThenBlock.new.call
+  test 'the step chain termination (and_then block)' do
+    instance_result1 = InstanceFirstSuccessToTerminateTheStepChainAndThenBlock.new.call
+    instance_result2 = InstanceSecondSuccessToTerminateTheStepChainAndThenBlock.new.call
+    instance_result3 = InstanceThirdSuccessToTerminateTheStepChainAndThenBlock.new.call
 
-    singleton_result1 = SingletonFirstSuccessHaltsTheStepChainAndThenBlock.call
-    singleton_result2 = SingletonSecondSuccessHaltsTheStepChainAndThenBlock.call
-    singleton_result3 = SingletonThirdSuccessHaltsTheStepChainAndThenBlock.call
+    singleton_result1 = SingletonFirstSuccessToTerminateTheStepChainAndThenBlock.call
+    singleton_result2 = SingletonSecondSuccessToTerminateTheStepChainAndThenBlock.call
+    singleton_result3 = SingletonThirdSuccessToTerminateTheStepChainAndThenBlock.call
 
-    assert(instance_result1.success?(:first) && instance_result1.halted?)
-    assert(instance_result2.success?(:second) && instance_result2.halted?)
-    assert(instance_result3.success?(:third) && instance_result3.halted?)
+    assert(instance_result1.success?(:first) && instance_result1.terminal?)
+    assert(instance_result2.success?(:second) && instance_result2.terminal?)
+    assert(instance_result3.success?(:third) && instance_result3.terminal?)
 
-    assert(singleton_result1.success?(:first) && singleton_result1.halted?)
-    assert(singleton_result2.success?(:second) && singleton_result2.halted?)
-    assert(singleton_result3.success?(:third) && singleton_result3.halted?)
+    assert(singleton_result1.success?(:first) && singleton_result1.terminal?)
+    assert(singleton_result2.success?(:second) && singleton_result2.terminal?)
+    assert(singleton_result3.success?(:third) && singleton_result3.terminal?)
   end
 
-  class InstanceFirstSuccessHaltsTheStepChainAndThenMethod
+  class InstanceFirstSuccessToTerminateTheStepChainAndThenMethod
     include BCDD::Result::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :first
@@ -245,7 +245,7 @@ class BCDD::Result::ExpectationsWithSubjectSuccessTypeTest < Minitest::Test
     def third_success;  Continue(:third); end
   end
 
-  class InstanceSecondSuccessHaltsTheStepChainAndThenMethod
+  class InstanceSecondSuccessToTerminateTheStepChainAndThenMethod
     include BCDD::Result::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :second
@@ -264,7 +264,7 @@ class BCDD::Result::ExpectationsWithSubjectSuccessTypeTest < Minitest::Test
     def third_success;  Continue(:third); end
   end
 
-  class InstanceThirdSuccessHaltsTheStepChainAndThenMethod
+  class InstanceThirdSuccessToTerminateTheStepChainAndThenMethod
     include BCDD::Result::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :third
@@ -283,7 +283,7 @@ class BCDD::Result::ExpectationsWithSubjectSuccessTypeTest < Minitest::Test
     def third_success;  Success(:third); end
   end
 
-  module SingletonFirstSuccessHaltsTheStepChainAndThenMethod
+  module SingletonFirstSuccessToTerminateTheStepChainAndThenMethod
     extend self, BCDD::Result::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :first
@@ -302,7 +302,7 @@ class BCDD::Result::ExpectationsWithSubjectSuccessTypeTest < Minitest::Test
     def third_success;  Continue(:third); end
   end
 
-  module SingletonSecondSuccessHaltsTheStepChainAndThenMethod
+  module SingletonSecondSuccessToTerminateTheStepChainAndThenMethod
     extend self, BCDD::Result::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :second
@@ -321,7 +321,7 @@ class BCDD::Result::ExpectationsWithSubjectSuccessTypeTest < Minitest::Test
     def third_success;  Continue(:third); end
   end
 
-  module SingletonThirdSuccessHaltsTheStepChainAndThenMethod
+  module SingletonThirdSuccessToTerminateTheStepChainAndThenMethod
     extend self, BCDD::Result::Expectations.mixin(
       config: { addon: { continue: true } },
       success: :third
@@ -340,13 +340,13 @@ class BCDD::Result::ExpectationsWithSubjectSuccessTypeTest < Minitest::Test
     def third_success;  Success(:third); end
   end
 
-  test 'the step chain halting (and_then calling a method)' do
-    instance_result1 = InstanceFirstSuccessHaltsTheStepChainAndThenMethod.new.call
-    instance_result2 = InstanceSecondSuccessHaltsTheStepChainAndThenMethod.new.call
-    instance_result3 = InstanceThirdSuccessHaltsTheStepChainAndThenMethod.new.call
+  test 'the step chain termination (and_then calling a method)' do
+    instance_result1 = InstanceFirstSuccessToTerminateTheStepChainAndThenMethod.new.call
+    instance_result2 = InstanceSecondSuccessToTerminateTheStepChainAndThenMethod.new.call
+    instance_result3 = InstanceThirdSuccessToTerminateTheStepChainAndThenMethod.new.call
 
-    assert(instance_result1.success?(:first) && instance_result1.halted?)
-    assert(instance_result2.success?(:second) && instance_result2.halted?)
-    assert(instance_result3.success?(:third) && instance_result3.halted?)
+    assert(instance_result1.success?(:first) && instance_result1.terminal?)
+    assert(instance_result2.success?(:second) && instance_result2.terminal?)
+    assert(instance_result3.success?(:third) && instance_result3.terminal?)
   end
 end

--- a/test/bcdd/result/failure_test.rb
+++ b/test/bcdd/result/failure_test.rb
@@ -12,10 +12,10 @@ class BCDD::Result
       assert Failure < BCDD::Result::Failure::Methods
     end
 
-    test '#halted?' do
+    test '#terminal?' do
       result = Failure.new(type: :err, value: nil)
 
-      assert_predicate result, :halted?
+      assert_predicate result, :terminal?
     end
 
     test '#success? should return false' do

--- a/test/bcdd/result/success_test.rb
+++ b/test/bcdd/result/success_test.rb
@@ -12,10 +12,10 @@ class BCDD::Result
       assert Success < BCDD::Result::Success::Methods
     end
 
-    test '#halted?' do
+    test '#terminal?' do
       result = Success.new(type: :ok, value: nil)
 
-      refute_predicate result, :halted?
+      refute_predicate result, :terminal?
     end
 
     test '#success? without receiving a type/argument' do

--- a/test/bcdd/result_test.rb
+++ b/test/bcdd/result_test.rb
@@ -46,10 +46,10 @@ module BCDD
       assert_raises(BCDD::Result::Error::NotImplemented) { result.failure?(:err) }
     end
 
-    test '#halted?' do
+    test '#terminal?' do
       result = Result.new(type: :err, value: 0)
 
-      refute_predicate(result, :halted?)
+      refute_predicate(result, :terminal?)
     end
 
     test '#value_or' do

--- a/test/railway_oriented_programming/result/and_then_test.rb
+++ b/test/railway_oriented_programming/result/and_then_test.rb
@@ -32,7 +32,7 @@ class BCDD::RailwayOrientedProgrammingAndThenTest < Minitest::Test
     end
   end
 
-  test '#and_then result halting/chaining' do
+  test 'terminal results' do
     success = Divide.call(10, 2)
 
     failure1 = Divide.call('10', 0)

--- a/test/railway_oriented_programming/result_mixin/instance_test.rb
+++ b/test/railway_oriented_programming/result_mixin/instance_test.rb
@@ -39,7 +39,7 @@ class BCDD::RailwayOrientedProgrammingResultMixinInstanceTest < Minitest::Test
     end
   end
 
-  test 'result halting/chaining with an instance (instance methods)' do
+  test 'terminal results with an instance (instance methods)' do
     success = Divide.new(10, 2).call
 
     failure1 = Divide.new('10', 0).call

--- a/test/railway_oriented_programming/result_mixin/singleton_test.rb
+++ b/test/railway_oriented_programming/result_mixin/singleton_test.rb
@@ -32,7 +32,7 @@ class BCDD::RailwayOrientedProgrammingResultMixinSingletonTest < Minitest::Test
     end
   end
 
-  test 'result halting/chaining with a module (singleton methods)' do
+  test 'terminal results with a module (singleton methods)' do
     success = Divide.call(10, 2)
 
     failure1 = Divide.call('10', 0)


### PR DESCRIPTION
From dictionary:
> of, forming, or situated at the end or extremity of something.
>
>  the end of a railroad or other transport route, or a station at such a point.

From Wikipedia:
> A "terminus" or "terminal" is a station at the end of a railway line.

